### PR TITLE
Check for '#!' to prevent shebang fix mishaps

### DIFF
--- a/config/software/shebang-cleanup.rb
+++ b/config/software/shebang-cleanup.rb
@@ -56,7 +56,9 @@ build do
 
         File.open(bin_file) do |f|
           shebang = f.readline
-          if shebang.include?("ruby") && !shebang.include?("#{install_dir}/embedded/bin/ruby")
+          if shebang.start_with?("#!") &&
+              shebang.include?("ruby") &&
+              !shebang.include?("#{install_dir}/embedded/bin/ruby")
             rest_of_the_file = f.read
             update_shebang = true
           end


### PR DESCRIPTION
When fixing up shebangs, skip the file if the first two characters aren't `#!`. This is expected to fix https://github.com/opscode/chef/issues/2677 (but will need a test build to confirm).