### PR TITLE
Remove SLES and openSUSE from the publish matrix

### DIFF
--- a/jenkins/chef.json
+++ b/jenkins/chef.json
@@ -4,22 +4,12 @@
             "el",
             "5",
             "x86_64"
-        ],
-        [
-            "sles",
-            "11.2",
-            "x86_64"
         ]
     ],
     "build_os=centos-5,machine_architecture=x86,role=oss-builder": [
         [
             "el",
             "5",
-            "i686"
-        ],
-        [
-            "sles",
-            "11.2",
             "i686"
         ]
     ],
@@ -33,22 +23,12 @@
             "el",
             "7",
             "x86_64"
-        ],
-        [
-            "suse",
-            "12.1",
-            "x86_64"
         ]
     ],
     "build_os=centos-6,machine_architecture=x86,role=oss-builder": [
         [
             "el",
             "6",
-            "i686"
-        ],
-        [
-            "suse",
-            "12.1",
             "i686"
         ]
     ],


### PR DESCRIPTION
These platforms are Tier 2 according to the official Chef platform support policy:
https://github.com/opscode/chef-rfc/blob/master/rfc021-platform-support-policy.md

Even though we no longer test these platforms, end-users will still be able to install the correct EL package based on the Omnitruck platform mappings:
https://github.com/opscode/opscode-omnitruck/blob/master/platforms.rb#L76-L90

/cc @opscode/release-engineers @lamont-granquist @danielsdeleo @jdmundrawala @adamedx @charlesjohnson 